### PR TITLE
Theme fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bequestinc/wui",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "author": "Bequest, Inc.",
   "license": "MIT",
   "private": false,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bequestinc/wui",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "author": "Bequest, Inc.",
   "license": "MIT",
   "private": false,

--- a/src/basics/CustomIcon.md
+++ b/src/basics/CustomIcon.md
@@ -9,12 +9,11 @@ With Theme Color:
 
 ```jsx
 import CheckCircleIcon from '@material-ui/icons/CheckCircle';
-import { ThemeProvider } from '@material-ui/core/styles';
-import theme from '../theme';
+import { WuiThemeProvider } from '../theme';
 
-<ThemeProvider theme={theme}>
+<WuiThemeProvider>
   <CustomIcon src={CheckCircleIcon} color={theme => theme.palette.green.success} />
-</ThemeProvider>;
+</WuiThemeProvider>;
 ```
 
 With Size:

--- a/src/basics/Modal.md
+++ b/src/basics/Modal.md
@@ -1,8 +1,7 @@
 ```jsx
-import { ThemeProvider } from '@material-ui/core/styles';
-import theme from '../theme';
+import { WuiThemeProvider } from '../theme';
 
-<ThemeProvider theme={theme}>
+<WuiThemeProvider>
   <div style={{ position: 'relative' }}>
     <Modal
       open
@@ -16,5 +15,5 @@ import theme from '../theme';
       This is the content.
     </Modal>
   </div>
-</ThemeProvider>;
+</WuiThemeProvider>;
 ```

--- a/src/basics/Spinner.md
+++ b/src/basics/Spinner.md
@@ -7,13 +7,12 @@ Plain
 With theme colors
 
 ```jsx
-import { ThemeProvider } from '@material-ui/core/styles';
-import theme from '../theme';
+import { WuiThemeProvider } from '../theme';
 
-<ThemeProvider theme={theme}>
+<WuiThemeProvider>
   <Spinner
     color={theme => theme.palette.green.success}
     background={theme => theme.palette.common.white}
   />
-</ThemeProvider>;
+</WuiThemeProvider>;
 ```

--- a/src/input/Checkbox.md
+++ b/src/input/Checkbox.md
@@ -1,19 +1,17 @@
 ```jsx
-import { ThemeProvider } from '@material-ui/core/styles';
-import theme from '../theme';
+import { WuiThemeProvider } from '../theme';
 
-<ThemeProvider theme={theme}>
+<WuiThemeProvider>
   <Checkbox label="Unchecked" />
   <Checkbox label="Unchecked disabled" disabled />
-</ThemeProvider>;
+</WuiThemeProvider>;
 ```
 
 ```jsx
-import { ThemeProvider } from '@material-ui/core/styles';
-import theme from '../theme';
+import { WuiThemeProvider } from '../theme';
 
-<ThemeProvider theme={theme}>
+<WuiThemeProvider>
   <Checkbox label="Checked" checked />
   <Checkbox label="Checked disabled" checked disabled />
-</ThemeProvider>;
+</WuiThemeProvider>;
 ```

--- a/src/input/Combobox.md
+++ b/src/input/Combobox.md
@@ -1,8 +1,7 @@
 ```jsx
 import React, { useState } from 'react';
 import Button from './button';
-import { ThemeProvider } from '@material-ui/core/styles';
-import theme from '../theme';
+import { WuiThemeProvider } from '../theme';
 
 const options = [
   'Apple',
@@ -46,7 +45,7 @@ const Example = () => {
   );
 };
 
-<ThemeProvider theme={theme}>
+<WuiThemeProvider>
   <Example />
-</ThemeProvider>;
+</WuiThemeProvider>;
 ```

--- a/src/input/DatePicker.md
+++ b/src/input/DatePicker.md
@@ -2,8 +2,7 @@
 import React from 'react';
 import DateFnsUtils from '@date-io/date-fns';
 import { MuiPickersUtilsProvider } from 'material-ui-pickers';
-import { ThemeProvider } from '@material-ui/core/styles';
-import theme from '../theme';
+import { WuiThemeProvider } from '../theme';
 
 import DatePicker from './datePicker';
 
@@ -23,7 +22,7 @@ function log(date) {
   console.log(date);
 }
 
-<ThemeProvider theme={theme}>
+<WuiThemeProvider>
   <MuiPickersUtilsProvider utils={DateFnsUtils}>
     {Object.entries(textboxes).map(([name, props]) => (
       <div key={name}>
@@ -32,5 +31,5 @@ function log(date) {
       </div>
     ))}
   </MuiPickersUtilsProvider>
-</ThemeProvider>;
+</WuiThemeProvider>;
 ```

--- a/src/input/Dropdown.md
+++ b/src/input/Dropdown.md
@@ -1,14 +1,13 @@
 ```jsx
 import Spacer from '..//layout/spacer';
 import Typography from '../basics/typography';
-import { ThemeProvider } from '@material-ui/core/styles';
-import theme from '../theme';
+import { WuiThemeProvider } from '../theme';
 
 function onClick(option) {
   console.log(`You clicked: ${option.label}!`);
 }
 
-<ThemeProvider theme={theme}>
+<WuiThemeProvider>
   <Typography variant="medium">
     <Spacer inline h={100} />
     <Dropdown
@@ -20,5 +19,5 @@ function onClick(option) {
       ]}
     />
   </Typography>
-</ThemeProvider>;
+</WuiThemeProvider>;
 ```

--- a/src/input/Fab.md
+++ b/src/input/Fab.md
@@ -1,7 +1,6 @@
 ```jsx
 import AddIcon from '@material-ui/icons/Add';
-import { ThemeProvider } from '@material-ui/core/styles';
-import theme from '../theme';
+import { WuiThemeProvider } from '../theme';
 
 import Fab from './fab';
 import Spacer from '../layout/spacer';
@@ -12,7 +11,7 @@ const buttons = {
   'Icon on Right': { icon: AddIcon, iconAlign: 'right' },
 };
 
-<ThemeProvider theme={theme}>
+<WuiThemeProvider>
   {Object.entries(buttons).map(([name, props]) => (
     <div key={name}>
       <Fab {...props} label={name} />
@@ -20,5 +19,5 @@ const buttons = {
       <Fab disabled {...props} label={`${name} Disabled`} />
     </div>
   ))}
-</ThemeProvider>;
+</WuiThemeProvider>;
 ```

--- a/src/input/Textbox.md
+++ b/src/input/Textbox.md
@@ -1,6 +1,5 @@
 ```jsx
-import { ThemeProvider } from '@material-ui/core/styles';
-import theme from '../theme';
+import { WuiThemeProvider } from '../theme';
 
 const longErrorMessage = Array(5)
   .fill('This is a very long error message.')
@@ -14,12 +13,12 @@ const textboxes = {
   'With Helper Text': { helperText: 'This is helper text.' },
 };
 
-<ThemeProvider theme={theme}>
+<WuiThemeProvider>
   {Object.entries(textboxes).map(([name, props]) => (
     <div key={name}>
       <Textbox value="" {...props} label={name} />
       <Textbox disabled value="" {...props} label={`Disabled ${name}`} />
     </div>
   ))}
-</ThemeProvider>;
+</WuiThemeProvider>;
 ```

--- a/src/input/radioGroup.jsx
+++ b/src/input/radioGroup.jsx
@@ -124,7 +124,9 @@ class RadioGroup extends React.Component {
         </Typography>
       );
 
-      const radio = <StyledRadio {...rest} data-value={value} color="primary" />;
+      const radio = (
+        <StyledRadio {...rest} onChange={this.dotsChanged} data-value={value} color="primary" />
+      );
 
       return (
         <FormControlLabel

--- a/src/layout/BorderedBox.md
+++ b/src/layout/BorderedBox.md
@@ -1,12 +1,11 @@
 ```jsx
-import { ThemeProvider } from '@material-ui/core/styles';
-import theme from '../theme';
+import { WuiThemeProvider } from '../theme';
 
 const examples = {
   Standard: {},
 };
 
-<ThemeProvider theme={theme}>
+<WuiThemeProvider>
   <div>
     {Object.entries(examples).map(([name, props]) => (
       <BorderedBox key={name} {...props}>
@@ -14,5 +13,5 @@ const examples = {
       </BorderedBox>
     ))}
   </div>
-</ThemeProvider>;
+</WuiThemeProvider>;
 ```

--- a/src/layout/Carousel.md
+++ b/src/layout/Carousel.md
@@ -1,6 +1,5 @@
 ```jsx
-import { ThemeProvider } from '@material-ui/core/styles';
-import theme from '../theme';
+import { WuiThemeProvider } from '../theme';
 import { withStyles } from '@material-ui/core';
 import Paper from '@material-ui/core/Paper';
 import Spacer from './spacer';
@@ -27,7 +26,7 @@ const slides = [
   </FullHeightPaper>
 ));
 
-<ThemeProvider theme={theme}>
+<WuiThemeProvider>
   <Carousel>{slides}</Carousel>
-</ThemeProvider>;
+</WuiThemeProvider>;
 ```

--- a/src/layout/grid.md
+++ b/src/layout/grid.md
@@ -1,9 +1,9 @@
 ```jsx
-import { ThemeProvider } from '@material-ui/core/styles';
+import { WuiThemeProvider } from '../theme';
 import theme from '../theme';
 import BorderedBox from './borderedBox';
 
-<ThemeProvider theme={theme}>
+<WuiThemeProvider>
   <Grid container direction="row" reverseDirectionOnPhone>
     <Grid item xs={4}>
       <BorderedBox>LEFT</BorderedBox>
@@ -12,5 +12,5 @@ import BorderedBox from './borderedBox';
       <BorderedBox>RIGHT</BorderedBox>
     </Grid>
   </Grid>
-</ThemeProvider>;
+</WuiThemeProvider>;
 ```

--- a/src/theme.jsx
+++ b/src/theme.jsx
@@ -1,4 +1,5 @@
-import { createMuiTheme } from '@material-ui/core/styles';
+import React from 'react';
+import { createMuiTheme, ThemeProvider } from '@material-ui/core/styles';
 import planHealthMeterGradient from './planHealthMeter';
 
 import { addTypography } from './basics/typography';
@@ -203,5 +204,7 @@ theme.layout.disabledNode = {
   pointerEvents: 'none',
 };
 theme.layout.paperPadding = 32;
+
+export const WuiThemeProvider = props => <ThemeProvider {...props} theme={theme} />;
 
 export default theme;


### PR DESCRIPTION
Through some unfortunate coincidence we've had the exact same version of MUI pinned for both the Willing app and WUI. We shouldn't depend on that. That is bad and we should feel bad for doing it.

The theme providers rely on object identity that is non-deterministic under later React versions, meaning we can count on them *not* being the same between the transpiled WUI and our non-transpiled apps, so we can run two theme providers in parallel.

Since the Willing app needs to switch the theme provider between this WUI theme and a different MUI theme (see aforementioned note about us being bad), we can have this running at a top level without it interfering with our other components.