### PR TITLE
Use custom prefix for jss classes used by wui components

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bequestinc/wui",
-  "version": "1.2.5",
+  "version": "1.2.6",
   "author": "Bequest, Inc.",
   "license": "MIT",
   "private": false,

--- a/src/theme.jsx
+++ b/src/theme.jsx
@@ -1,5 +1,10 @@
 import React from 'react';
-import { createMuiTheme, ThemeProvider } from '@material-ui/core/styles';
+import {
+  createMuiTheme,
+  createGenerateClassName,
+  ThemeProvider,
+  StylesProvider,
+} from '@material-ui/core/styles';
 import planHealthMeterGradient from './planHealthMeter';
 
 import { addTypography } from './basics/typography';
@@ -205,6 +210,14 @@ theme.layout.disabledNode = {
 };
 theme.layout.paperPadding = 32;
 
-export const WuiThemeProvider = props => <ThemeProvider {...props} theme={theme} />;
+const generateClassName = createGenerateClassName({
+  productionPrefix: 'wui-jss',
+});
+
+export const WuiThemeProvider = props => (
+  <StylesProvider generateClassName={generateClassName}>
+    <ThemeProvider {...props} theme={theme} />
+  </StylesProvider>
+);
 
 export default theme;


### PR DESCRIPTION
Testing this was pretty painful, but it works. After this is released we should just have to bump the version number on wui in the willing app.