### PR TITLE
Apply wui prefix during SSR

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bequestinc/wui",
-  "version": "1.2.6",
+  "version": "1.2.7",
   "author": "Bequest, Inc.",
   "license": "MIT",
   "private": false,

--- a/src/theme.jsx
+++ b/src/theme.jsx
@@ -215,7 +215,7 @@ const generateClassName = createGenerateClassName({
 });
 
 export const WuiThemeProvider = props => (
-  <StylesProvider generateClassName={generateClassName}>
+  <StylesProvider generateClassName={generateClassName} serverGenerateClassName={generateClassName}>
     <ThemeProvider {...props} theme={theme} />
   </StylesProvider>
 );


### PR DESCRIPTION
During server side rendering, the wui-jss prefix is not currently applied. This causes a mismatch between the server side and client side DOM during hydration.

I hope that I'm not relying on an unstable API here (the serverGenerateClassName prop isn't listed in the material-ui documentation), but the solutions for this problem listed in the docs were not working for me.