### PR TITLE
Use new generateClassName function for each WuiThemeProvider

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bequestinc/wui",
-  "version": "1.2.7",
+  "version": "1.2.8",
   "author": "Bequest, Inc.",
   "license": "MIT",
   "private": false,

--- a/src/theme.jsx
+++ b/src/theme.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useRef } from 'react';
 import {
   createMuiTheme,
   createGenerateClassName,
@@ -210,14 +210,20 @@ theme.layout.disabledNode = {
 };
 theme.layout.paperPadding = 32;
 
-const generateClassName = createGenerateClassName({
-  productionPrefix: 'wui-jss',
-});
-
-export const WuiThemeProvider = props => (
-  <StylesProvider generateClassName={generateClassName} serverGenerateClassName={generateClassName}>
-    <ThemeProvider {...props} theme={theme} />
-  </StylesProvider>
-);
+export const WuiThemeProvider = props => {
+  const generateClassName = useRef(
+    createGenerateClassName({
+      productionPrefix: 'wui-jss',
+    }),
+  );
+  return (
+    <StylesProvider
+      generateClassName={generateClassName.current}
+      serverGenerateClassName={generateClassName.current}
+    >
+      <ThemeProvider {...props} theme={theme} />
+    </StylesProvider>
+  );
+};
 
 export default theme;


### PR DESCRIPTION
During server side rendering, the same generateClassName function
was being used to generate class names across different requests.
This worked fine during static generation, but for server side
rendering the counter in the class name would increase arbitrarily
and not match the client side render. This ensures that a new
generateClassName is passed for each request and memoizes it so
that it does not change on rerender.

After deploying members with the latest wui version, I noticed that it was working as expected for pages that used static generation, but not those with SSR (just the index for now). This feels kind of hacky, but should fix the problem. Open to any suggestions on a better way. I used a ref instead of useMemo or useCallback because React does not guarantee that it won't clear the cache for those hooks.