### PR TITLE
Add aria-label field to input elements

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bequestinc/wui",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "author": "Bequest, Inc.",
   "license": "MIT",
   "private": false,

--- a/src/input/textbox.jsx
+++ b/src/input/textbox.jsx
@@ -263,6 +263,7 @@ const Textbox = ({
   const { inputProps: InputPropsInputProps = {}, ...remainingInputProps } = InputProps || {};
 
   const combinedInputProps = {
+    'aria-label': label,
     ...InputPropsInputProps,
     ...inputProps,
   };


### PR DESCRIPTION
Without delving too deep into MUI's internals, this is what we need for A11Y compliance. The input field already has a label element that `react-axe` isn't picking up, but this adds it for screen readers.