### PR TITLE
THEME: error red needs to be darker for AA compliance

### DIFF
--- a/src/theme.jsx
+++ b/src/theme.jsx
@@ -30,6 +30,9 @@ const theme = createMuiTheme({
       secondary: '#525252',
       superhero: inputText,
     },
+    error: {
+      main: '#DE0007',
+    },
     grey: {
       inputText,
       textboxBorder,


### PR DESCRIPTION
The color contrast for the following 2 error types in portunus don't meet the AA standard.  One is on the form helper text and the other is general form errors.  I figured making this change would be easier to do once in `wui `rather than using `makeStyles` multiple times in the individual components.  But if you think applying the style to each component in portunus using `makeStyles` is better, let me know!

FYI the images below are using the AA compliant darker shade of red (#DE0007) not the default mui shade. 

![wui_helpererror](https://user-images.githubusercontent.com/64965386/94757248-b221b380-0367-11eb-96c2-31d5f1ffb011.png)
![wui_formerror](https://user-images.githubusercontent.com/64965386/94757253-b352e080-0367-11eb-925d-81e8fc2052d2.png)

Also, I'm not 100% sure that what I did here is going to work, but I will test once it gets merged.  