### PR TITLE
Export old version of theme provider

### DIFF
--- a/src/theme.jsx
+++ b/src/theme.jsx
@@ -229,4 +229,14 @@ export const WuiThemeProvider = props => {
   );
 };
 
+const generateClassName = createGenerateClassName({
+  productionPrefix: 'wui-jss',
+});
+
+export const StaticWuiThemeProvider = props => (
+  <StylesProvider generateClassName={generateClassName} serverGenerateClassName={generateClassName}>
+    <ThemeProvider {...props} theme={theme} />
+  </StylesProvider>
+);
+
 export default theme;


### PR DESCRIPTION
I can't figure out why the new theme provider is causing problems for estate-planning, but it is. If someone else can figure it out we can export a single provider again, but for now I think this is easiest.