### PR TITLE
v4 to support react-18

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bequestinc/wui",
   "license": "MIT",
-  "version": "3.2.1",
+  "version": "4.0.0",
   "author": "Bequest, Inc.",
   "private": false,
   "scripts": {


### PR DESCRIPTION
due to all of our repos using ^ with packages, supporting react 18 should've been released with a new major version rather than a new minor version. the two releases (3.2.0 & 3.2.1) have been unpublished from npm, and this pr will take their place