### PR TITLE
remove main from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
     "storybook": "start-storybook -p 6006",
     "build-storybook": "build-storybook"
   },
-  "main": "lib/index.js",
   "devDependencies": {
     "@babel/cli": "^7.13.16",
     "@babel/core": "^7.14.0",


### PR DESCRIPTION
closes #63 

as our main entry point is index.js, I *think* we don't even need the main field. this should also fix that annoying warning about it. if possible, lets merge this before the table component so we can just have 1 release 