### PR TITLE
update modal to remove warnings from console

### DIFF
--- a/src/Modal.js
+++ b/src/Modal.js
@@ -11,16 +11,8 @@ import Typography from '@mui/material/Typography';
 import { makeStyles } from './theme';
 
 const useStyles = makeStyles()(theme => ({
-  title: {
-    padding: theme.spacing(2),
-  },
   content: {
     padding: theme.spacing(2),
-  },
-  closeButton: {
-    position: 'absolute',
-    right: theme.spacing(1),
-    top: theme.spacing(1),
   },
 }));
 
@@ -29,12 +21,22 @@ const Modal = ({ title, open, onClose, children, ...props }) => {
 
   return (
     <Dialog onClose={onClose} open={open} {...props}>
-      <DialogTitle className={classes.title}>
+      <DialogTitle
+        sx={{
+          display: 'flex',
+        }}
+      >
         <Typography variant="h6" component="div">
           {title}
         </Typography>
 
-        <IconButton aria-label="close" className={classes.closeButton} onClick={onClose}>
+        <IconButton
+          aria-label="close"
+          onClick={onClose}
+          sx={{
+            marginLeft: 'auto',
+          }}
+        >
           <CloseIcon />
         </IconButton>
       </DialogTitle>

--- a/src/Modal.js
+++ b/src/Modal.js
@@ -29,8 +29,11 @@ const Modal = ({ title, open, onClose, children, ...props }) => {
 
   return (
     <Dialog onClose={onClose} open={open} {...props}>
-      <DialogTitle disableTypography className={classes.title}>
-        <Typography variant="h6">{title}</Typography>
+      <DialogTitle className={classes.title}>
+        <Typography variant="h6" component="div">
+          {title}
+        </Typography>
+
         <IconButton aria-label="close" className={classes.closeButton} onClick={onClose}>
           <CloseIcon />
         </IconButton>

--- a/src/stories/Modal.stories.js
+++ b/src/stories/Modal.stories.js
@@ -12,8 +12,17 @@ const Template = args => <Modal {...args} />;
 export const ModalScreen = Template.bind({});
 
 ModalScreen.args = {
-  title: 'title',
+  title: 'This Is An Example Title',
   open: true,
   onClose: () => {},
-  children: <div>children</div>,
+  children: (
+    <div>
+      Cras mattis consectetur purus sit amet fermentum. Cras justo odio, dapibus ac facilisis in,
+      egestas eget quam. Morbi leo risus, porta ac consectetur ac, vestibulum at eros. Praesent
+      commodo cursus magna, vel scelerisque nisl consectetur et. Vivamus sagittis lacus vel augue
+      laoreet rutrum faucibus dolor auctor. Aenean lacinia bibendum nulla sed consectetur. Praesent
+      commodo cursus magna, vel scelerisque nisl consectetur et. Donec sed odio dui. Donec
+      ullamcorper nulla non metus auctor fringilla.
+    </div>
+  ),
 };


### PR DESCRIPTION
this will get rid of the 2 warnings that have been showing in the console anytime the Modal component is used. 

1. the disableTypography no longer exists
2. the dialog title by default uses an h2 element and the specified h6 typography element can't be a child of an h2

also, before and after this change, the close modal X icon shows below the title rather than to the right of it (which to me, to the right of it looks a lot better) do we really want it to show below the title?