### PR TITLE
Update publish.yml

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,6 +10,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      - name: Install Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16
+          registry-url: 'https://registry.npmjs.org'
       - uses: pnpm/action-setup@v2
         with:
           version: 7
@@ -20,4 +25,4 @@ jobs:
       - name: Publish to NPM
         run: pnpm publish
         env:
-          NPM_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}


### PR DESCRIPTION
it looks like when using `actions/setup-node@v3`, you have to explicitly define the registry URL. more on this can be found [here](https://github.com/pnpm/pnpm/issues/3141) and [here](https://docs.github.com/en/actions/publishing-packages/publishing-nodejs-packages?query=node_auth_token) 