### PR TITLE
Add borders around buttons for contrast

### DIFF
--- a/src/input/Button.md
+++ b/src/input/Button.md
@@ -1,0 +1,19 @@
+```jsx
+import { WuiThemeProvider } from '../theme';
+
+import Spacer from '../layout/spacer';
+
+<WuiThemeProvider>
+  <div style={{ display: 'flex', flexDirection: 'column', width: 400 }}>
+    <Button variant="text">Text Button</Button>
+    <Spacer v={30} />
+    <Button variant="outlined">Outlined Button</Button>
+    <Spacer v={30} />
+    <Button color="primary" variant="contained">
+      Contained Button
+    </Button>
+    <Spacer v={30} />
+    <Button color="primary">Button</Button>
+  </div>
+</WuiThemeProvider>;
+```

--- a/src/input/button.jsx
+++ b/src/input/button.jsx
@@ -29,7 +29,6 @@ const styles = theme => ({
     letterSpacing: 0.5,
     position: 'relative',
     textTransform: 'none',
-    borderRadius: theme.dimensions.borderRadius,
 
     [theme.breakpoints.phone]: {
       minWidth: 'auto',
@@ -42,17 +41,24 @@ const styles = theme => ({
         backgroundColor: 'transparent',
       },
     },
+    '&:focus': {
+      border: [[2, 'solid', 'white']],
+      outline: [[2, 'solid', '#2A4283']],
+      borderRadius: 0,
+    },
   },
   text: {
-    padding: 0,
+    padding: 4,
     fontSize: 18,
     minWidth: 'auto',
     lineHeight: '28px',
     color: theme.palette.text.secondary,
+    textDecoration: 'underline',
+    width: 'fit-content',
 
     '&:hover, &:focus': {
       background: 'none',
-      textDecoration: 'underline',
+      textDecoration: 'none',
     },
   },
   contained: {
@@ -72,7 +78,8 @@ const styles = theme => ({
 
     '&:focus': {
       boxShadow: 'none',
-      background: theme.palette.blue.focus,
+      backgroundColor: '#2A4283',
+      borderRadius: 3,
     },
 
     '&$disabled:hover, &$disabled': {
@@ -106,8 +113,7 @@ const styles = theme => ({
     },
 
     '&:focus': {
-      borderColor: theme.palette.blue.default,
-      background: theme.palette.background.default,
+      color: '#3752A9',
     },
 
     '&$disabled:hover, &$disabled': {

--- a/src/input/fab.jsx
+++ b/src/input/fab.jsx
@@ -10,7 +10,6 @@ import Typography from '@/basics/typography';
 const side = 44;
 const border = 6;
 const textMargin = 8;
-const hoverIncrease = 4;
 
 const styles = theme => ({
   // Used to modify other classes.
@@ -54,25 +53,19 @@ const styles = theme => ({
     justifyContent: 'center',
     color: theme.palette.common.white,
     boxShadow: theme.customShadows.fab,
-    background: theme.palette.blue.textboxFocus,
+    background: '#3752A9',
 
     '$root:hover &, $root$focusVisible &': {
       boxShadow: theme.customShadows.fabHover,
       background: theme.palette.blue.checkboxCheck,
     },
 
-    '$root:hover &': {
-      minWidth: side + hoverIncrease,
-      minHeight: side + hoverIncrease,
-      margin: [[0, (border - hoverIncrease) * 2]],
-    },
-
     '$root$focusVisible &': {
       margin: 0,
       boxShadow: 'none',
-      minWidth: side + border * 2,
-      minHeight: side + border * 2,
-      border: [[6, 'solid', '#dfe9fd']],
+      border: [[2, 'solid', '#FFFFFF']],
+      outline: [[2, 'solid', '#2A4283']],
+      backgroundColor: '#2A4283',
     },
   },
   icon: {


### PR DESCRIPTION
![Screenshot from 2024-01-31 13-04-47](https://github.com/MetLifeLegalPlans/wui/assets/89038780/bca61d82-67cc-415f-8430-5ec665323c5f)
![Screenshot from 2024-01-31 13-04-29](https://github.com/MetLifeLegalPlans/wui/assets/89038780/9b1ab677-e675-41dc-af0b-bdcdb8c09959)

Adds borders around buttons when focused on to add contrast to make it clearer that it is selected. 

Fabs no longer change in size when hovered/focused 