### PR TITLE
temporarily export all of MRT

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bequestinc/wui",
   "license": "MIT",
-  "version": "5.1.4",
+  "version": "5.2.4",
   "author": "Bequest, Inc.",
   "private": false,
   "main": "dist/wui.umd.js",

--- a/src/index.js
+++ b/src/index.js
@@ -4,5 +4,5 @@ export { default as Modal } from './components/Modal.jsx';
 export { default as ConfirmDeleteButton } from './components/ConfirmDeleteButton.jsx';
 export { default as CustomTable } from './components/table/CustomTable.jsx';
 export { default as CustomTableWithActions } from './components/table/CustomTableWithActions.jsx';
-export { useMaterialReactTable } from 'material-react-table';
-export { MaterialReactTable } from 'material-react-table';
+// this is temporary until we have the time to move our custom components above to v3
+export * as MRT from 'material-react-table';


### PR DESCRIPTION
I'm wanting to use the `MRT_TableHeadCellFilterContainer` component (this works in tandem with `columnFilterDisplayMode: 'custom')` so for the time being, I think just exporting everything from MRT is easiest